### PR TITLE
Update Readme - new version of Vault & typo fix

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,8 +39,8 @@ If you are using a Mac with homebrew, this is as simple as:
 
 Alternatively, download Vault for your operating system from https://www.vaultproject.io/downloads.html:
 
-    $ https://releases.hashicorp.com/vault/0.8.3/vault_0.8.3_darwin_amd64.zip
-    $ unzip vault_0.8.3_darwin_amd64.zip
+    $ https://releases.hashicorp.com/vault/0.10.2/vault_0.10.2_darwin_amd64.zip
+    $ unzip vault_0.10.2_darwin_amd64
 
 For other systems with package management, such as Redhat, Ubuntu, Debian, CentOS, and Windows, see instructions at https://www.vaultproject.io/docs/install/index.html.
 
@@ -68,13 +68,13 @@ Launch another console window to store application configuration in Vault using 
 First, you need to set two environment variables to point the Vault CLI to the Vault endpoint and provide
 an authentication token.
 
-    $ export export VAULT_TOKEN="00000000-0000-0000-0000-000000000000"
+    $ export VAULT_TOKEN="00000000-0000-0000-0000-000000000000"
     $ export VAULT_ADDR="http://127.0.0.1:8200"
 
 Now you can store a configuration key-value pairs inside Vault:
 
-    $ vault write secret/gs-vault-config example.username=demouser example.password=demopassword
-    $ vault write secret/gs-vault-config/cloud example.username=clouduser example.password=cloudpassword
+    $ vault kv put secret/gs-vault-config example.username=demouser example.password=demopassword
+    $ vault kv put secret/gs-vault-config/cloud example.username=clouduser example.password=cloudpassword
 
 Now you have written two entries in Vault `secret/gs-vault` and `secret/gs-vault-config/cloud`.
 


### PR DESCRIPTION
- Fix a typo on the export env var statements (export was typed twice)
- Update the download of vault examples to the latest one 0.10.2
- With the upate of Vault - the CLI has changed when you want to add secrets its not `write` any more