### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -1,14 +1,14 @@
 :spring_version: current
 :spring_boot_version: 2.1.3.RELEASE
-:Controller: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
-:DispatcherServlet: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
-:SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
-:ResponseBody: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/bind/annotation/ResponseBody.html
+:Controller: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
+:DispatcherServlet: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
+:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
+:ResponseBody: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/bind/annotation/ResponseBody.html
 :toc:
 :icons: font
 :source-highlighter: prettify
 :project_id: gs-vault-config
-This guide walks you through the process of using http://cloud.spring.io/spring-cloud-vault/[Spring Cloud Vault] to build an application that retrieves its configuration properties from https://www.vaultproject.io[HashiCorp Vault].
+This guide walks you through the process of using https://cloud.spring.io/spring-cloud-vault/[Spring Cloud Vault] to build an application that retrieves its configuration properties from https://www.vaultproject.io[HashiCorp Vault].
 
 == What you'll build
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-vault/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-vault/ ([https](https://cloud.spring.io/spring-cloud-vault/) result 200).
* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 3 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8200 with 1 occurrences