### PR TITLE
Clean up merge conflict

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,17 +1,9 @@
 :spring_version: current
-<<<<<<< HEAD
-:spring_boot_version: 2.1.3.RELEASE
-:Controller: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
-:DispatcherServlet: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
-:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
-:ResponseBody: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/bind/annotation/ResponseBody.html
-=======
 :spring_boot_version: 2.1.4.RELEASE
 :Controller: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/stereotype/Controller.html
 :DispatcherServlet: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/servlet/DispatcherServlet.html
 :SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
 :ResponseBody: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/web/bind/annotation/ResponseBody.html
->>>>>>> Upgrade to Spring Boot 2.1.4.RELEASE.
 :toc:
 :icons: font
 :source-highlighter: prettify


### PR DESCRIPTION
There seems to have been a merge conflict unhandled.
This causes the guide to be rendered incorrectly.
See: https://spring.io/guides/gs/vault-config/

This pull request handles the merge conflict.