### PR TITLE
Removed bootstrap reference and updated versions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -90,13 +90,12 @@ include::complete/src/main/java/hello/MyConfiguration.java[]
 
 == Configure your application
 
-Here you configure your application with `bootstrap.properties`. Spring Cloud Vault operates in the bootstrap context to initially
-obtain configuration properties so it can provide these to the auto-configuration and your application itself.
+Here you configure your application with `application.properties`. The code below uses Spring Boot's Config Data API which allows importing configuration from Vault.
 
-`src/main/resources/bootstrap.properties`
+`src/main/resources/application.properties`
 [source,properties]
 ----
-include::complete/src/main/resources/bootstrap.properties[]
+include::complete/src/main/resources/application.properties[]
 ----
 
 == Create an Application class

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.3.2.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.7.0")
     }
 }
 
@@ -13,25 +13,29 @@ apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
 
-bootJar {
-    baseName = 'gs-vault-config'
-    version =  '0.1.0'
+jar {
+    archiveBaseName = 'gs-vault-config'
+    archiveVersion =  '0.1.0'
 }
 
 repositories {
     mavenCentral()
 }
 
+test {
+    useJUnitPlatform()
+}
+
 ext {
-    springCloudVersion = 'Greenwich.SR2'
+    springCloudVersion = '2021.0.3'
 }
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile('org.springframework.cloud:spring-cloud-starter-vault-config')
-    testCompile("org.springframework.boot:spring-boot-starter-test")
+    implementation 'org.springframework.cloud:spring-cloud-starter-vault-config'
+    testImplementation "org.springframework.boot:spring-boot-starter-test"
 }
 
 dependencyManagement {

--- a/complete/gradle/wrapper/gradle-wrapper.properties
+++ b/complete/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.2.RELEASE</version>
+        <version>2.7.0</version>
     </parent>
 
     <dependencies>
@@ -42,7 +42,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <spring-cloud.version>Greenwich.SR2</spring-cloud.version>
+        <spring-cloud.version>2021.0.3</spring-cloud.version>
     </properties>
 
     <build>

--- a/complete/src/main/resources/application.properties
+++ b/complete/src/main/resources/application.properties
@@ -2,3 +2,4 @@ spring.application.name=gs-vault-config
 spring.cloud.vault.token=00000000-0000-0000-0000-000000000000
 spring.cloud.vault.scheme=http
 spring.cloud.vault.kv.enabled=true
+spring.config.import:  vault://

--- a/complete/src/test/java/hello/MyConfigurationTests.java
+++ b/complete/src/test/java/hello/MyConfigurationTests.java
@@ -15,18 +15,16 @@
  */
 package hello;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Mark Paluch
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest
 public class MyConfigurationTests {
 
@@ -35,7 +33,6 @@ public class MyConfigurationTests {
 
 	@Test
 	public void shouldContainConfigurationProperties() {
-
 		assertThat(myConfiguration.getUsername()).isNotEmpty();
 		assertThat(myConfiguration.getPassword()).isNotEmpty();
 	}

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.3.2.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.7.0")
     }
 }
 
@@ -13,25 +13,29 @@ apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
 
-bootJar {
-    baseName = 'gs-vault-config'
-    version =  '0.1.0'
+jar {
+    archiveBaseName = 'gs-vault-config'
+    archiveVersion =  '0.1.0'
 }
 
 repositories {
     mavenCentral()
 }
 
+test {
+    useJUnitPlatform()
+}
+
 ext {
-    springCloudVersion = 'Greenwich.SR2'
+    springCloudVersion = '2021.0.3'
 }
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile('org.springframework.cloud:spring-cloud-starter-vault-config')
-    testCompile("org.springframework.boot:spring-boot-starter-test")
+    implementation 'org.springframework.cloud:spring-cloud-starter-vault-config'
+    testImplementation "org.springframework.boot:spring-boot-starter-test"
 }
 
 dependencyManagement {

--- a/initial/gradle/wrapper/gradle-wrapper.properties
+++ b/initial/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.springframework</groupId>
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.2.RELEASE</version>
+        <version>2.7.0</version>
     </parent>
 
     <dependencies>
@@ -42,7 +42,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <spring-cloud.version>Greenwich.SR2</spring-cloud.version>
+        <spring-cloud.version>2021.0.3</spring-cloud.version>
     </properties>
 
     <build>


### PR DESCRIPTION
The current guide relied on Spring Boot using bootstrap.properties.  Since that was discontinued I moved the configuration to `application.properties` and added `spring.config.import:  vault://`

Updated versions of Spring Boot, Spring Cloud, Gradle, and JUnit along the way.